### PR TITLE
Fix: apply cache name when sending events

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const maxAge = require('./lib/maxAge');
 const staleIfError = require('./lib/staleIfError');
-const events = require('./lib/cache').events;
+const events = require('./lib/events').emitter;
 
 module.exports = {
   maxAge,

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -2,17 +2,11 @@
 
 const _ = require('lodash');
 const bluebird = require('bluebird');
-const EventEmitter = require('events');
+const events = require('./events');
 
 const VERSION = require('../package').version;
 
-const events = new EventEmitter();
 const TimeoutError = bluebird.TimeoutError;
-
-function emitEvent(event, name) {
-  const type = name ? `cache.${name}.${event}` : `cache.${event}`;
-  events.emit(type);
-}
 
 function createCacheKey(segment, id) {
   const versionedSegment = `http-transport:${VERSION}:${segment}`;
@@ -27,15 +21,10 @@ function getFromCache(cache, segment, id, opts) {
   let pending = new Promise((resolve, reject) => {
     cache.get(createCacheKey(segment, id), (err, cached) => {
       if (err) {
-        emitEvent('error', cache.name);
+        events.emitCacheEvent('error', opts);
         return reject(err);
       }
 
-      if (!cached) {
-        emitEvent('miss', cache.name);
-      } else {
-        emitEvent('hit', cache.name);
-      }
       resolve(cached);
     });
   });
@@ -49,7 +38,7 @@ function getFromCache(cache, segment, id, opts) {
 
   return pending.catch((err) => {
     if (err instanceof TimeoutError) {
-      emitEvent('timeout', cache.name);
+      events.emitCacheEvent('timeout', opts);
     }
 
     if (_.get(opts, 'ignoreCacheErrors', false)) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const EventEmitter = require('events');
+const events = new EventEmitter();
+
+function emitCacheEvent(event, opts) {
+  const name = opts && opts.name ? opts.name : null;
+  const type = name ? `cache.${name}.${event}` : `cache.${event}`;
+  events.emit(type);
+}
+
+module.exports = {
+  emitter: events,
+  emitCacheEvent
+};

--- a/lib/maxAge.js
+++ b/lib/maxAge.js
@@ -7,6 +7,7 @@ const parseCacheControl = require('./parseCacheControl');
 const getFromCache = require('./cache').getFromCache;
 const storeInCache = require('./cache').storeInCache;
 const toResponse = require('./toResponse');
+const events = require('./events');
 
 const MAX_AGE = 'max-age';
 const STALE_WHILST_REVALIDATE = 'stale-while-revalidate';
@@ -52,8 +53,11 @@ module.exports = (cache, opts) => {
           revalidate(cached, ctx.req.getUrl(), cache, opts);
         }
         ctx.res = toResponse(cached);
+        events.emitCacheEvent('hit', opts);
         return;
       }
+
+      events.emitCacheEvent('miss', opts);
 
       return next().then(() => {
         if (ctx.isStale || ctx.res.statusCode >= 400) return;

--- a/lib/staleIfError.js
+++ b/lib/staleIfError.js
@@ -5,7 +5,7 @@ const parseCacheControl = require('./parseCacheControl');
 const getFromCache = require('./cache').getFromCache;
 const storeInCache = require('./cache').storeInCache;
 const toResponse = require('./toResponse');
-const events = require('./cache').events;
+const events = require('./events');
 
 const STALE_IF_ERROR = 'stale-if-error';
 const MAX_AGE = 'max-age';
@@ -34,7 +34,7 @@ module.exports = (cache, opts) => {
         }
       })
       .catch((err) => {
-        return getFromCache(cache, SEGMENT, ctx.req.getUrl())
+        return getFromCache(cache, SEGMENT, ctx.req.getUrl(), opts)
           .catch((cacheErr) => {
             if (_.get(opts, 'ignoreCacheErrors', false)) throw err;
             throw cacheErr;
@@ -43,7 +43,7 @@ module.exports = (cache, opts) => {
             if (cached) {
               ctx.isStale = true;
               ctx.res = toResponse(cached);
-              events.emit('cache.stale');
+              events.emitCacheEvent('stale', opts);
               return;
             }
 


### PR DESCRIPTION
* Passing in a cache with `name` field is no longer supported for sending stats
* Instead, `name` is part of the options passed into the middleware, e.g.

```js
httpTransport.use(httpTransportCache.maxAge(cache, { name: 'somecache' });
```

* This also fixes sending `hit`/`miss` stats events alongside `staleIfError` events