### PR TITLE
Ignore errors when starting

### DIFF
--- a/lib/maxAge.js
+++ b/lib/maxAge.js
@@ -25,7 +25,12 @@ function getExpiry(ctx, cacheControl) {
 module.exports = (cache, opts) => {
   return async (ctx, next) => {
     if (!cache.isReady()) {
-      await cache.start();
+      try {
+        await cache.start();
+      } catch (err) {
+        if (_.get(opts, 'ignoreCacheErrors', false)) return next();
+        throw err;
+      }
     }
 
     const cached = await getFromCache(cache, SEGMENT, ctx.req.getRequestKey(), opts, ctx);

--- a/lib/staleIfError.js
+++ b/lib/staleIfError.js
@@ -19,7 +19,12 @@ class HttpError extends Error { }
 module.exports = (cache, opts) => {
   return async (ctx, next) => {
     if (!cache.isReady()) {
-      await cache.start();
+      try {
+        await cache.start();
+      } catch (err) {
+        if (_.get(opts, 'ignoreCacheErrors', false)) return next();
+        throw err;
+      }
     }
 
     let cached;

--- a/test/maxAge.js
+++ b/test/maxAge.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const assert = require('assert');
+const assert = require('chai').assert;
+const { rejects, doesNotReject } = require('assert');
 const httpTransport = require('@bbc/http-transport');
 const Catbox = require('catbox');
 const Memory = require('catbox-memory');
@@ -73,7 +74,7 @@ describe('Max-Age', () => {
     const startError = new Error('Error starting da cache');
     sandbox.stub(cache, 'start').rejects(startError);
 
-    assert.rejects(() => requestWithCache(cache, { ignoreCacheErrors: false }), startError);
+    rejects(() => requestWithCache(cache, { ignoreCacheErrors: false }), startError);
   });
 
   it('does not throw the error that starting the cache throws and continues to next middleware when ignoreCacheErrors is true', async () => {
@@ -95,7 +96,7 @@ describe('Max-Age', () => {
         .asResponse();
     }
 
-    await assert.doesNotReject(requestWithCacheAndNextMiddleware, /Error starting da cache/);
+    await doesNotReject(requestWithCacheAndNextMiddleware, /Error starting da cache/);
     assert.equal(called, true, 'Expected the next middleware to be called');
   });
 
@@ -145,7 +146,7 @@ describe('Max-Age', () => {
 
     const cached = await catbox.get(bodySegment);
 
-    assert.strictEqual(cached, null);
+    assert.isNull(cached);
   });
 
   it('does create cache entries for client errors', async () => {
@@ -189,7 +190,7 @@ describe('Max-Age', () => {
 
     const cachedItem = await nearCache.get(bodySegment);
 
-    assert(cachedItem.ttl < 59950);
+    assert.isBelow(cachedItem.ttl, 59950);
   });
 
   it('ignore cache lookup errors', async () => {
@@ -224,7 +225,7 @@ describe('Max-Age', () => {
         .get('http://www.example.com/')
         .asBody();
     } catch (err) {
-      assert.strictEqual(cacheLookupComplete, false);
+      assert.isFalse(cacheLookupComplete);
       return assert.equal(err.message, `Cache timed out after ${timeout}`);
     }
     assert.fail('Expected to throw');
@@ -251,7 +252,7 @@ describe('Max-Age', () => {
     } catch (err) {
       return assert.fail(null, null, 'Failed on timeout');
     }
-    assert.strictEqual(cacheLookupComplete, false);
+    assert.isFalse(cacheLookupComplete);
     assert.equal(body, defaultResponse.body);
   });
 
@@ -390,7 +391,7 @@ describe('Max-Age', () => {
 
     await requestWithCache(cache);
     const cached = await cache.get(bodySegment);
-    assert.strictEqual(cached, null);
+    assert.isNull(cached);
   });
 
   it('does not store if private', async () => {
@@ -400,7 +401,7 @@ describe('Max-Age', () => {
 
     await requestWithCache(cache);
     const cached = await cache.get(bodySegment);
-    assert.strictEqual(cached, null);
+    assert.isNull(cached);
   });
 
   describe('Events', () => {
@@ -460,7 +461,7 @@ describe('Max-Age', () => {
       await requestWithCache(cache);
       await requestWithCache(cache);
 
-      assert(context instanceof httpTransport.context);
+      assert.instanceOf(context, httpTransport.context);
     });
 
     it('returns a context from a cache miss event emission', async () => {
@@ -474,7 +475,7 @@ describe('Max-Age', () => {
 
       await requestWithCache(cache);
 
-      assert(context instanceof httpTransport.context);
+      assert.instanceOf(context, httpTransport.context);
     });
 
     it('returns a context from a cache timeout event emission', async () => {
@@ -493,7 +494,7 @@ describe('Max-Age', () => {
       try {
         await requestWithCache(cache, { timeout: 10 });
       } catch (err) {
-        return assert(context instanceof httpTransport.context);
+        return assert.instanceOf(context, httpTransport.context);
       }
 
       assert.fail('Expected to throw');
@@ -513,7 +514,7 @@ describe('Max-Age', () => {
       try {
         await requestWithCache(cache);
       } catch (err) {
-        return assert(context instanceof httpTransport.context);
+        return assert.instanceOf(context, httpTransport.context);
       }
 
       assert.fail('Expected to throw');

--- a/test/maxAge.js
+++ b/test/maxAge.js
@@ -76,13 +76,27 @@ describe('Max-Age', () => {
     assert.rejects(() => requestWithCache(cache, { ignoreCacheErrors: false }), startError);
   });
 
-  it('does not throw the error that starting the cache throws when ignoreCacheErrors is true', async () => {
-    api.get('/').thrice().reply(200, defaultResponse.body, defaultHeaders);
-    const cache = createCache();
+  it('does not throw the error that starting the cache throws and continues to next middleware when ignoreCacheErrors is true', async () => {
+    const catbox = createCache();
     const startError = new Error('Error starting da cache');
-    sandbox.stub(cache, 'start').rejects(startError);
+    sandbox.stub(catbox, 'start').rejects(startError);
+    api.get('/').thrice().reply(200, defaultResponse.body, defaultHeaders);
 
-    return assert.doesNotReject(() => requestWithCache(cache, { ignoreCacheErrors: true }), /Error starting da cache/);
+    let called = false;
+    function requestWithCacheAndNextMiddleware() {
+      return httpTransport
+        .createClient()
+        .use(cache.maxAge(catbox, { ignoreCacheErrors: true }))
+        .use((ctx, next) => {
+          called = true;
+          return next();
+        })
+        .get('http://www.example.com/')
+        .asResponse();
+    }
+
+    await assert.doesNotReject(requestWithCacheAndNextMiddleware, /Error starting da cache/);
+    assert.equal(called, true, 'Expected the next middleware to be called');
   });
 
   it('stores cached values for the max-age value', async () => {

--- a/test/staleIfError.js
+++ b/test/staleIfError.js
@@ -202,7 +202,7 @@ describe('Stale-If-Error', () => {
       .asResponse();
 
     const cachedItem = await nearCache.get(bodySegment);
-    assert.strictEqual(cachedItem, null);
+    assert.isNull(cachedItem);
   });
 
   it('does not store if no cache-control', async () => {
@@ -288,7 +288,6 @@ describe('Stale-If-Error', () => {
 
     return cache.drop(bodySegment);
   });
-
   it('returns the original error if nothing in cache', async () => {
     const cache = createCache();
     api.get('/').reply(500, defaultResponse, {});

--- a/test/staleIfError.js
+++ b/test/staleIfError.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const assert = require('assert');
+const assert = require('chai').assert;
+const { rejects, doesNotReject } = require('assert');
 const Catbox = require('catbox');
 const Memory = require('catbox-memory');
 const nock = require('nock');
@@ -74,7 +75,7 @@ describe('Stale-If-Error', () => {
     const startError = new Error('Error starting da cache');
     sandbox.stub(cache, 'start').rejects(startError);
 
-    return assert.rejects(() => requestWithCache(cache, { ignoreCacheErrors: false }), startError);
+    return rejects(() => requestWithCache(cache, { ignoreCacheErrors: false }), startError);
   });
 
   it('does not throw the error that starting the cache throws and continues to next middleware when ignoreCacheErrors is true', async () => {
@@ -96,7 +97,7 @@ describe('Stale-If-Error', () => {
         .asResponse();
     }
 
-    await assert.doesNotReject(requestWithCacheAndNextMiddleware, /Error starting da cache/);
+    await doesNotReject(requestWithCacheAndNextMiddleware, /Error starting da cache/);
     assert.strictEqual(called, true, 'Expected the next middleware to be called');
   });
 
@@ -161,7 +162,7 @@ describe('Stale-If-Error', () => {
       .asResponse();
 
     const cached = await catbox.get(bodySegment);
-    assert.strictEqual(cached, null);
+    assert.isNull(cached);
   });
 
   it('does create cache entries for client errors', async () => {
@@ -221,7 +222,7 @@ describe('Stale-If-Error', () => {
 
     await requestWithCache(cache);
     const cached = await cache.get(bodySegment);
-    assert.strictEqual(cached, null);
+    assert.isNull(cached);
   });
 
   it('does not store if no-store', async () => {
@@ -231,7 +232,7 @@ describe('Stale-If-Error', () => {
 
     await requestWithCache(cache);
     const cached = await cache.get(bodySegment);
-    assert.strictEqual(cached, null);
+    assert.isNull(cached);
   });
 
   it('does not store if private', async () => {
@@ -241,7 +242,7 @@ describe('Stale-If-Error', () => {
 
     await requestWithCache(cache);
     const cached = await cache.get(bodySegment);
-    assert.strictEqual(cached, null);
+    assert.isNull(cached);
   });
 
   it('stores even if no max-age', async () => {
@@ -410,7 +411,7 @@ describe('Stale-If-Error', () => {
       await cache.set(bodySegment, cachedResponse, 7200);
       await requestWithCache(cache, opts);
 
-      assert(context instanceof httpTransport.context);
+      assert.instanceOf(context, httpTransport.context);
     });
 
     it('emits a timeout cache event with the correct context', async () => {
@@ -432,7 +433,7 @@ describe('Stale-If-Error', () => {
       try {
         await requestWithCache(cache, { timeout: 10 });
       } catch (err) {
-        return assert(context instanceof httpTransport.context);
+        return assert.instanceOf(context, httpTransport.context);
       }
 
       assert.fail('Expected to throw');
@@ -455,7 +456,7 @@ describe('Stale-If-Error', () => {
       try {
         await requestWithCache(cache);
       } catch (err) {
-        return assert(context instanceof httpTransport.context);
+        return assert.instanceOf(context, httpTransport.context);
       }
 
       assert.fail('Expected to throw');

--- a/test/staleIfError.js
+++ b/test/staleIfError.js
@@ -59,7 +59,7 @@ describe('Stale-If-Error', () => {
 
   it('starts the cache if it\'s not already started', async () => {
     const cache = createCache();
-    sandbox.stub(cache, 'start');
+    sandbox.spy(cache, 'start');
 
     api.get('/').reply(200, defaultResponse.body, defaultHeaders);
 
@@ -74,7 +74,7 @@ describe('Stale-If-Error', () => {
     const startError = new Error('Error starting da cache');
     sandbox.stub(cache, 'start').rejects(startError);
 
-    assert.rejects(() => requestWithCache(cache, { ignoreCacheErrors: false }), startError);
+    return assert.rejects(() => requestWithCache(cache, { ignoreCacheErrors: false }), startError);
   });
 
   it('does not throw the error that starting the cache throws when ignoreCacheErrors is true', async () => {
@@ -83,7 +83,7 @@ describe('Stale-If-Error', () => {
     const startError = new Error('Error starting da cache');
     sandbox.stub(cache, 'start').rejects(startError);
 
-    assert.doesNotReject(() => requestWithCache(cache, { ignoreCacheErrors: true }), startError);
+    return assert.doesNotReject(() => requestWithCache(cache, { ignoreCacheErrors: true }), /Error starting da cache/);
   });
 
   it('stores cached values for the stale-if-error value', async () => {


### PR DESCRIPTION
This change means that if you have passed in the `ignoreCacheErrors` option, if there are issues connecting to Redis when it tries to start the connection, these errors will also be silently ignored and the request will be made on the network rather than to the cache.