### PR TITLE
Emit error object in error events

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -54,9 +54,9 @@ async function getFromCache(cache, segment, ctx, opts) {
     return value;
   } catch (err) {
     if (err instanceof TimeoutError) {
-      events.emitCacheEvent('timeout', opts, ctx);
+      events.emitCacheEvent('timeout', opts, ctx, err);
     } else {
-      events.emitCacheEvent('error', opts, ctx);
+      events.emitCacheEvent('error', opts, ctx, err);
     }
     throw err;
   }
@@ -76,9 +76,9 @@ async function storeInCache(cache, segment, ctx, body, ttl, opts) {
     events.emitCacheEvent('write_time', opts, duration);
   } catch (err) {
     if (err instanceof TimeoutError) {
-      events.emitCacheEvent('timeout', opts, ctx);
+      events.emitCacheEvent('timeout', opts, ctx, err);
     } else {
-      events.emitCacheEvent('error', opts, ctx);
+      events.emitCacheEvent('error', opts, ctx, err);
     }
   }
 }


### PR DESCRIPTION
Currently when an error event is emitted the error object is not included. This means that if you were to use this error for logging then you would not have access to it to provide a sensible error message. This PR adds the relevant error object to error events when they are emitted.  