### PR TITLE
Returning cache status ("hit", "miss", "stale" etc) in context

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Both `maxage` and `staleIfError` accept an options object.
 |`timeout`|integer|maxAge|Timeouts a cache lookup after a specified number of ms. By default, no timeout is specified.|
 |`connectionTimeout`|integer|maxAge,staleIfError|Timeouts the attempt to connect to a cache after a specified number of ms. By default, no timeout is specified.|
 |`connectionCircuitBreakerOptions`|object|maxAge,staleIfError| When present an instance of [Levee](https://github.com/krakenjs/levee) will be created with these configuration options to use on connection to cache.|
-|`includeCacheStatusInCtx`|boolean|maxAge,staleIfError| When present, `cacheStatus` will be set in `context.res` for use by other plugins. `includeCacheStatusInCtx` is `false` by default.|
+|`includeCacheStatusInCtx`|boolean|maxAge,staleIfError| When present, `cacheStatus` will be set in `context` for use by other plugins. `includeCacheStatusInCtx` is `false` by default.|
 
 ## Cache Key Structure
  

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Both `maxage` and `staleIfError` accept an options object.
 |`timeout`|integer|maxAge|Timeouts a cache lookup after a specified number of ms. By default, no timeout is specified.|
 |`connectionTimeout`|integer|maxAge,staleIfError|Timeouts the attempt to connect to a cache after a specified number of ms. By default, no timeout is specified.|
 |`connectionCircuitBreakerOptions`|object|maxAge,staleIfError| When present an instance of [Levee](https://github.com/krakenjs/levee) will be created with these configuration options to use on connection to cache.|
+|`includeCacheStatusInCtx`|boolean|maxAge,staleIfError| When present, `cacheStatus` will be set in `context.res` for use by other plugins. `includeCacheStatusInCtx` is `false` by default.|
 
 ## Cache Key Structure
  

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -54,8 +54,14 @@ async function getFromCache(cache, segment, ctx, opts) {
     return value;
   } catch (err) {
     if (err instanceof TimeoutError) {
+      if (_.get(opts, 'includeCacheStatusInCtx', false)) {
+        ctx.res.cacheStatus = 'timeout';
+      }
       events.emitCacheEvent('timeout', opts, ctx, err);
     } else {
+      if (_.get(opts, 'includeCacheStatusInCtx', false)) {
+        ctx.res.cacheStatus = 'error';
+      }
       events.emitCacheEvent('error', opts, ctx, err);
     }
     throw err;
@@ -76,8 +82,14 @@ async function storeInCache(cache, segment, ctx, body, ttl, opts) {
     events.emitCacheEvent('write_time', opts, duration);
   } catch (err) {
     if (err instanceof TimeoutError) {
+      if (_.get(opts, 'includeCacheStatusInCtx', false)) {
+        ctx.res.cacheStatus = 'timeout';
+      }
       events.emitCacheEvent('timeout', opts, ctx, err);
     } else {
+      if (_.get(opts, 'includeCacheStatusInCtx', false)) {
+        ctx.res.cacheStatus = 'error';
+      }
       events.emitCacheEvent('error', opts, ctx, err);
     }
   }

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -54,8 +54,14 @@ async function getFromCache(cache, segment, ctx, opts) {
     return value;
   } catch (err) {
     if (err instanceof TimeoutError) {
+      if (_.get(opts, 'includeCacheStatusInCtx', false)) {
+        ctx.cacheStatus = 'timeout';
+      }
       events.emitCacheEvent('timeout', opts, ctx, err);
     } else {
+      if (_.get(opts, 'includeCacheStatusInCtx', false)) {
+        ctx.cacheStatus = 'error';
+      }
       events.emitCacheEvent('error', opts, ctx, err);
     }
     throw err;
@@ -76,8 +82,14 @@ async function storeInCache(cache, segment, ctx, body, ttl, opts) {
     events.emitCacheEvent('write_time', opts, duration);
   } catch (err) {
     if (err instanceof TimeoutError) {
+      if (_.get(opts, 'includeCacheStatusInCtx', false)) {
+        ctx.cacheStatus = 'timeout';
+      }
       events.emitCacheEvent('timeout', opts, ctx, err);
     } else {
+      if (_.get(opts, 'includeCacheStatusInCtx', false)) {
+        ctx.cacheStatus = 'error';
+      }
       events.emitCacheEvent('error', opts, ctx, err);
     }
   }

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -54,14 +54,8 @@ async function getFromCache(cache, segment, ctx, opts) {
     return value;
   } catch (err) {
     if (err instanceof TimeoutError) {
-      if (_.get(opts, 'includeCacheStatusInCtx', false)) {
-        ctx.res.cacheStatus = 'timeout';
-      }
       events.emitCacheEvent('timeout', opts, ctx, err);
     } else {
-      if (_.get(opts, 'includeCacheStatusInCtx', false)) {
-        ctx.res.cacheStatus = 'error';
-      }
       events.emitCacheEvent('error', opts, ctx, err);
     }
     throw err;
@@ -82,14 +76,8 @@ async function storeInCache(cache, segment, ctx, body, ttl, opts) {
     events.emitCacheEvent('write_time', opts, duration);
   } catch (err) {
     if (err instanceof TimeoutError) {
-      if (_.get(opts, 'includeCacheStatusInCtx', false)) {
-        ctx.res.cacheStatus = 'timeout';
-      }
       events.emitCacheEvent('timeout', opts, ctx, err);
     } else {
-      if (_.get(opts, 'includeCacheStatusInCtx', false)) {
-        ctx.res.cacheStatus = 'error';
-      }
       events.emitCacheEvent('error', opts, ctx, err);
     }
   }

--- a/lib/maxAge.js
+++ b/lib/maxAge.js
@@ -2,7 +2,6 @@
 
 const _ = require('lodash');
 const Levee = require('levee');
-const bluebird = require('bluebird');
 
 const parseCacheControl = require('./parseCacheControl');
 const getFromCache = require('./cache').getFromCache;
@@ -13,7 +12,6 @@ const events = require('./events');
 const directives = require('./directives');
 const startCacheConnection = require('./cacheConnection').startCacheConnection;
 const isCacheReady = require('./cacheConnection').isCacheReady;
-const TimeoutError = bluebird.TimeoutError;
 const MAX_AGE = 'max-age';
 const CACHE_CONTROL = 'cache-control';
 const SEGMENT = 'body';
@@ -43,12 +41,10 @@ module.exports = (cache, opts) => {
 
     let cacheErrored;
     let cached;
-    let cacheError;
     try {
       cached = await getFromCache(cache, SEGMENT, ctx, opts);
     } catch (error) {
       cacheErrored = true;
-      cacheError = error;
       if (_.get(opts, 'ignoreCacheErrors', false)) {
         cached = null;
       } else {
@@ -58,24 +54,17 @@ module.exports = (cache, opts) => {
 
     if (cached) {
       ctx.res = toResponse(cached);
-      if (_.get(opts, 'includeCacheStatusInCtx', false)) {
-        ctx.res.cacheStatus = 'hit';
+      if (_.get(opts, 'includeCacheStatusInCtx', true)) {
+        ctx.cacheStatus = 'hit';
       }
       events.emitCacheEvent('hit', opts, ctx);
       return;
     }
 
-    if (_.get(opts, 'includeCacheStatusInCtx', false)) {
-      ctx.res.cacheStatus = 'miss';
+    if (_.get(opts, 'includeCacheStatusInCtx', true)) {
+      ctx.cacheStatus = 'miss';
     }
 
-    if (cacheErrored && _.get(opts, 'includeCacheStatusInCtx', false)) {
-      if (cacheError instanceof TimeoutError) {
-        ctx.res.cacheStatus = 'timeout';
-      } else {
-        ctx.res.cacheStatus = 'error';
-      }
-    }
     events.emitCacheEvent('miss', opts, ctx);
 
     await next();

--- a/lib/maxAge.js
+++ b/lib/maxAge.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const Levee = require('levee');
+const bluebird = require('bluebird');
 
 const parseCacheControl = require('./parseCacheControl');
 const getFromCache = require('./cache').getFromCache;
@@ -12,6 +13,7 @@ const events = require('./events');
 const directives = require('./directives');
 const startCacheConnection = require('./cacheConnection').startCacheConnection;
 const isCacheReady = require('./cacheConnection').isCacheReady;
+const TimeoutError = bluebird.TimeoutError;
 const MAX_AGE = 'max-age';
 const CACHE_CONTROL = 'cache-control';
 const SEGMENT = 'body';
@@ -41,10 +43,12 @@ module.exports = (cache, opts) => {
 
     let cacheErrored;
     let cached;
+    let cacheError;
     try {
       cached = await getFromCache(cache, SEGMENT, ctx, opts);
     } catch (error) {
       cacheErrored = true;
+      cacheError = error;
       if (_.get(opts, 'ignoreCacheErrors', false)) {
         cached = null;
       } else {
@@ -60,8 +64,17 @@ module.exports = (cache, opts) => {
       events.emitCacheEvent('hit', opts, ctx);
       return;
     }
+
     if (_.get(opts, 'includeCacheStatusInCtx', false)) {
       ctx.res.cacheStatus = 'miss';
+    }
+
+    if (cacheErrored && _.get(opts, 'includeCacheStatusInCtx', false)) {
+      if (cacheError instanceof TimeoutError) {
+        ctx.res.cacheStatus = 'timeout';
+      } else {
+        ctx.res.cacheStatus = 'error';
+      }
     }
     events.emitCacheEvent('miss', opts, ctx);
 

--- a/lib/maxAge.js
+++ b/lib/maxAge.js
@@ -54,8 +54,14 @@ module.exports = (cache, opts) => {
 
     if (cached) {
       ctx.res = toResponse(cached);
+      if (_.get(opts, 'includeCacheStatusInCtx', false)) {
+        ctx.res.cacheStatus = 'hit';
+      }
       events.emitCacheEvent('hit', opts, ctx);
       return;
+    }
+    if (_.get(opts, 'includeCacheStatusInCtx', false)) {
+      ctx.res.cacheStatus = 'miss';
     }
     events.emitCacheEvent('miss', opts, ctx);
 

--- a/lib/staleIfError.js
+++ b/lib/staleIfError.js
@@ -49,6 +49,9 @@ module.exports = (cache, opts) => {
       if (cached) {
         ctx.isStale = true;
         ctx.res = toResponse(cached);
+        if (_.get(opts, 'includeCacheStatusInCtx', false)) {
+          ctx.res.cacheStatus = 'stale';
+        }
         events.emitCacheEvent('stale', opts, ctx);
         return;
       }

--- a/lib/staleIfError.js
+++ b/lib/staleIfError.js
@@ -2,7 +2,6 @@
 
 const _ = require('lodash');
 const Levee = require('levee');
-const bluebird = require('bluebird');
 const parseCacheControl = require('./parseCacheControl');
 const getFromCache = require('./cache').getFromCache;
 const storeInCache = require('./cache').storeInCache;
@@ -12,7 +11,6 @@ const events = require('./events');
 const directives = require('./directives');
 const startCacheConnection = require('./cacheConnection').startCacheConnection;
 const isCacheReady = require('./cacheConnection').isCacheReady;
-const TimeoutError = bluebird.TimeoutError;
 
 const STALE_IF_ERROR = 'stale-if-error';
 const MAX_AGE = 'max-age';
@@ -44,23 +42,14 @@ module.exports = (cache, opts) => {
       try {
         cached = await getFromCache(cache, SEGMENT, ctx, opts);
       } catch (cacheErr) {
-        if (_.get(opts, 'ignoreCacheErrors', false)) {
-          if (_.get(opts, 'includeCacheStatusInCtx', false)) {
-            if (cacheErr instanceof TimeoutError) {
-              ctx.res.cacheStatus = 'timeout';
-            } else {
-              ctx.res.cacheStatus = 'error';
-            }
-          }
-          throw err;
-        }
+        if (_.get(opts, 'ignoreCacheErrors', false)) throw err;
         throw cacheErr;
       }
 
       if (cached) {
         ctx.isStale = true;
         ctx.res = toResponse(cached);
-        if (_.get(opts, 'includeCacheStatusInCtx', false)) {
+        if (_.get(opts, 'includeCacheStatusInCtx', true)) {
           ctx.res.cacheStatus = 'stale';
         }
         events.emitCacheEvent('stale', opts, ctx);

--- a/lib/staleIfError.js
+++ b/lib/staleIfError.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const Levee = require('levee');
+const bluebird = require('bluebird');
 const parseCacheControl = require('./parseCacheControl');
 const getFromCache = require('./cache').getFromCache;
 const storeInCache = require('./cache').storeInCache;
@@ -11,6 +12,7 @@ const events = require('./events');
 const directives = require('./directives');
 const startCacheConnection = require('./cacheConnection').startCacheConnection;
 const isCacheReady = require('./cacheConnection').isCacheReady;
+const TimeoutError = bluebird.TimeoutError;
 
 const STALE_IF_ERROR = 'stale-if-error';
 const MAX_AGE = 'max-age';
@@ -42,7 +44,16 @@ module.exports = (cache, opts) => {
       try {
         cached = await getFromCache(cache, SEGMENT, ctx, opts);
       } catch (cacheErr) {
-        if (_.get(opts, 'ignoreCacheErrors', false)) throw err;
+        if (_.get(opts, 'ignoreCacheErrors', false)) {
+          if (_.get(opts, 'includeCacheStatusInCtx', false)) {
+            if (cacheErr instanceof TimeoutError) {
+              ctx.res.cacheStatus = 'timeout';
+            } else {
+              ctx.res.cacheStatus = 'error';
+            }
+          }
+          throw err;
+        }
         throw cacheErr;
       }
 

--- a/lib/staleIfError.js
+++ b/lib/staleIfError.js
@@ -50,7 +50,7 @@ module.exports = (cache, opts) => {
         ctx.isStale = true;
         ctx.res = toResponse(cached);
         if (_.get(opts, 'includeCacheStatusInCtx', true)) {
-          ctx.res.cacheStatus = 'stale';
+          ctx.cacheStatus = 'stale';
         }
         events.emitCacheEvent('stale', opts, ctx);
         return;

--- a/test/cache.js
+++ b/test/cache.js
@@ -166,7 +166,7 @@ describe('events', () => {
     assert.fail();
   });
 
-  it('sets the cacheStatus variable in context from a cache timeout', async () => {
+  it('sets the cacheStatus variable in context when retrieving from the cache times out', async () => {
     const cache = createCache();
     sandbox.stub(cache, 'get').callsFake(async () => {
       await bluebird.delay(100);
@@ -284,7 +284,7 @@ describe('events', () => {
     assert.fail();
   });
 
-  it('sets the cacheStatus variable in context from a cache timeout', async () => {
+  it('sets the cacheStatus variable in context when retrieving from the cache errors', async () => {
     const cache = createCache();
     sandbox.stub(cache, 'get').rejects(new Error('error'));
 

--- a/test/cache.js
+++ b/test/cache.js
@@ -177,6 +177,7 @@ describe('events', () => {
       eventContext = ctx;
     });
 
+    delete ctx.cacheStatus;
     const includeCacheStatusInCtx = true;
     await cache.start();
     try {
@@ -239,6 +240,8 @@ describe('events', () => {
     events.on('cache.timeout', (ctx) => {
       eventContext = ctx;
     });
+
+    delete ctx.cacheStatus;
     const includeCacheStatusInCtx = true;
     await cache.start();
     await storeInCache(cache, SEGMENT, ctx, body, 600, { timeout: 10, includeCacheStatusInCtx });
@@ -293,6 +296,7 @@ describe('events', () => {
       eventContext = ctx;
     });
 
+    delete ctx.cacheStatus;
     const includeCacheStatusInCtx = true;
     await cache.start();
     try {
@@ -405,6 +409,7 @@ describe('events', () => {
 
   it('sets the cacheStatus variable in context when storing in cache errors', async () => {
     const cache = createCache();
+    const body = { a: 1 };
     sandbox.stub(cache, 'set').rejects(new Error('error'));
 
     let cacheError = false;
@@ -412,9 +417,11 @@ describe('events', () => {
       cacheError = true;
     });
 
+    delete ctx.cacheStatus;
     const includeCacheStatusInCtx = true;
     await cache.start();
-    await storeInCache(cache, SEGMENT, ctx, { a: 1, includeCacheStatusInCtx }, 600);
+    await storeInCache(cache, SEGMENT, ctx, body, 600, { includeCacheStatusInCtx });
+
     assert.equal(ctx.cacheStatus, 'error');
     assert.ok(cacheError);
   });

--- a/test/maxAge.js
+++ b/test/maxAge.js
@@ -683,7 +683,7 @@ describe('Max-Age', () => {
       assert.instanceOf(context, httpTransport.context);
     });
 
-    it('sets the cacheStatus variable in context from a cache hit', async () => {
+    it('sets the cacheStatus variable in context when there is a cache hit', async () => {
       const cache = createCache();
       api.get('/').reply(200, defaultResponse, defaultHeaders);
 
@@ -714,7 +714,7 @@ describe('Max-Age', () => {
       assert.instanceOf(context, httpTransport.context);
     });
 
-    it('sets the cacheStatus variable in context from a cache miss', async () => {
+    it('sets the cacheStatus variable in context when there is a cache miss', async () => {
       const cache = createCache();
       api.get('/').reply(200, defaultResponse, defaultHeaders);
 

--- a/test/maxAge.js
+++ b/test/maxAge.js
@@ -683,6 +683,23 @@ describe('Max-Age', () => {
       assert.instanceOf(context, httpTransport.context);
     });
 
+    it('sets the cacheStatus variable in context from a cache hit', async () => {
+      const cache = createCache();
+      api.get('/').reply(200, defaultResponse, defaultHeaders);
+
+      let context;
+      events.on('cache.hit', (ctx) => {
+        context = ctx;
+      });
+
+      const includeCacheStatusInCtx = true;
+      await requestWithCache(cache, { includeCacheStatusInCtx });
+      await requestWithCache(cache, { includeCacheStatusInCtx });
+
+      assert.instanceOf(context, httpTransport.context);
+      assert.equal(context.cacheStatus, 'hit');
+    });
+
     it('returns a context from a cache miss event emission', async () => {
       const cache = createCache();
       api.get('/').reply(200, defaultResponse, defaultHeaders);
@@ -695,6 +712,22 @@ describe('Max-Age', () => {
       await requestWithCache(cache);
 
       assert.instanceOf(context, httpTransport.context);
+    });
+
+    it('sets the cacheStatus variable in context from a cache miss', async () => {
+      const cache = createCache();
+      api.get('/').reply(200, defaultResponse, defaultHeaders);
+
+      let context;
+      events.on('cache.miss', (ctx) => {
+        context = ctx;
+      });
+
+      const includeCacheStatusInCtx = true;
+      await requestWithCache(cache, { includeCacheStatusInCtx });
+
+      assert.instanceOf(context, httpTransport.context);
+      assert.equal(context.cacheStatus, 'miss');
     });
 
     it('returns a context from a cache timeout event emission', async () => {

--- a/test/staleIfError.js
+++ b/test/staleIfError.js
@@ -569,6 +569,29 @@ describe('Stale-If-Error', () => {
       assert.instanceOf(context, httpTransport.context);
     });
 
+    it('sets the cacheStatus variable in context when there is a stale cache', async () => {
+      const opts = {
+        name: 'ceych',
+        includeCacheStatusInCtx: true
+      };
+
+      let context;
+      events.on('cache.ceych.stale', (ctx) => {
+        context = ctx;
+      });
+
+      const cache = createCache();
+
+      api.get('/').reply(500, defaultResponse.body, {});
+
+      await cache.start();
+      await cache.set(bodySegment, cachedResponse, 7200);
+      await requestWithCache(cache, opts);
+
+      assert.instanceOf(context, httpTransport.context);
+      assert.equal(context.cacheStatus, 'stale');
+    });
+
     it('emits a timeout cache event with the correct context', async () => {
       const cache = createCache();
       api.get('/').reply(500, defaultResponse, defaultHeaders);


### PR DESCRIPTION
## Description
- Added a new option - `includeCacheStatusInCtx`. If set to true, will set the `cacheStatus` variable in context.
- Conditionally assign `cacheStatus` in the case of a cache `error`/`timeout`/`hit`/`miss`/`stale` depending on the presence of the `includeCacheStatusInCtx` option.
- Unit tested new additions.

## Motivation and Context
We (Sounds) are in the process of migrating to using EMF logs where we want to capture all logs/metrics for a single request in a single JSON object.

In order to capture all stats for a single request, we need to capture cache events for every request (and be confident that the event that was captured was indeed for that request). The current implementation for getting cache stats uses event emitters. When we have multiple endpoints with listeners to the same event name (`cache.rms.hit` for example), I don't think we can guarantee that the listener that fires is for the actual request that triggered it.

See https://github.com/bbc/http-transport-cache/issues/34 for full explanation.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
