### PR TITLE
Returning cache status ("hit", "miss", "stale" etc) in context

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Both `maxage` and `staleIfError` accept an options object.
 |`timeout`|integer|maxAge|Timeouts a cache lookup after a specified number of ms. By default, no timeout is specified.|
 |`connectionTimeout`|integer|maxAge,staleIfError|Timeouts the attempt to connect to a cache after a specified number of ms. By default, no timeout is specified.|
 |`connectionCircuitBreakerOptions`|object|maxAge,staleIfError| When present an instance of [Levee](https://github.com/krakenjs/levee) will be created with these configuration options to use on connection to cache.|
-|`includeCacheStatusInCtx`|boolean|maxAge,staleIfError| When present, `cacheStatus` will be set in `context.res` for use by other plugins. `includeCacheStatusInCtx` is `false` by default.|
+|`includeCacheStatusInCtx`|boolean|maxAge,staleIfError| When present, a `cacheStatus` array - recording all cache events, will be set in `context` for use by other plugins. `includeCacheStatusInCtx` is `false` by default.|
 
 ## Cache Key Structure
  

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Both `maxage` and `staleIfError` accept an options object.
 |`timeout`|integer|maxAge|Timeouts a cache lookup after a specified number of ms. By default, no timeout is specified.|
 |`connectionTimeout`|integer|maxAge,staleIfError|Timeouts the attempt to connect to a cache after a specified number of ms. By default, no timeout is specified.|
 |`connectionCircuitBreakerOptions`|object|maxAge,staleIfError| When present an instance of [Levee](https://github.com/krakenjs/levee) will be created with these configuration options to use on connection to cache.|
+|`includeCacheStatusInCtx`|boolean|maxAge,staleIfError| When present, `cacheStatus` will be set in `context.res` for use by other plugins. `includeCacheStatusInCtx` is `false` by default.|
 
 ## Cache Key Structure
  

--- a/lib/events.js
+++ b/lib/events.js
@@ -8,8 +8,13 @@ function emitCacheEvent(event, opts, ctx, err) {
   const name = opts && opts.name ? opts.name : null;
   const type = name ? `cache.${name}.${event}` : `cache.${event}`;
 
-  if (_.get(opts, 'includeCacheStatusInCtx', false)) {
+  if (_.get(opts, 'includeCacheStatusInCtx', true)) {
+    if (!_.get(ctx, 'cacheAudit')) {
+      ctx.cacheAudit = [];
+    }
+
     ctx.cacheStatus = event;
+    ctx.cacheAudit.push(event);
   }
 
   events.emit(type, ctx, err);

--- a/lib/events.js
+++ b/lib/events.js
@@ -1,11 +1,17 @@
 'use strict';
 
+const _ = require('lodash');
 const EventEmitter = require('events');
 const events = new EventEmitter();
 
 function emitCacheEvent(event, opts, ctx, err) {
   const name = opts && opts.name ? opts.name : null;
   const type = name ? `cache.${name}.${event}` : `cache.${event}`;
+
+  if (_.get(opts, 'includeCacheStatusInCtx', false)) {
+    ctx.cacheStatus = event;
+  }
+
   events.emit(type, ctx, err);
 }
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -8,7 +8,7 @@ function emitCacheEvent(event, opts, ctx, err) {
   const name = opts && opts.name ? opts.name : null;
   const type = name ? `cache.${name}.${event}` : `cache.${event}`;
 
-  if (_.get(opts, 'includeCacheStatusInCtx', true)) {
+  if (_.get(opts, 'includeCacheStatusInCtx', false)) {
     if (!_.get(ctx, 'cacheAudit')) {
       ctx.cacheAudit = [];
     }

--- a/lib/events.js
+++ b/lib/events.js
@@ -9,12 +9,11 @@ function emitCacheEvent(event, opts, ctx, err) {
   const type = name ? `cache.${name}.${event}` : `cache.${event}`;
 
   if (_.get(opts, 'includeCacheStatusInCtx', false)) {
-    if (!_.get(ctx, 'cacheAudit')) {
-      ctx.cacheAudit = [];
+    if (!_.get(ctx, 'cacheStatus')) {
+      ctx.cacheStatus = [];
     }
 
-    ctx.cacheStatus = event;
-    ctx.cacheAudit.push(event);
+    ctx.cacheStatus.push(event);
   }
 
   events.emit(type, ctx, err);


### PR DESCRIPTION
## Description
- Added a new option - `includeCacheStatusInCtx`. If set to true, will set the `cacheStatus` variable in context.
- Conditionally assign `cacheStatus` in the case of a cache `error`/`timeout`/`hit`/`miss`/`stale` depending on the presence of the `includeCacheStatusInCtx` option.
- Unit tested new additions.

## Motivation and Context
We (Sounds) are in the process of migrating to using EMF logs where we want to capture all logs/metrics for a single request in a single JSON object.

In order to capture all stats for a single request, we need to capture cache events for every request (and be confident that the event that was captured was indeed for that request). The current implementation for getting cache stats uses event emitters. When we have multiple endpoints with listeners to the same event name (`cache.rms.hit` for example), I don't think we can guarantee that the listener that fires is for the actual request that triggered it.

See https://github.com/bbc/http-transport-cache/issues/34 for full explanation.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
