### PR TITLE
Fixed duration being set in place of context in read_time and write_time events

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -50,13 +50,14 @@ async function getFromCache(cache, segment, ctx, opts) {
   try {
     const value = await pending;
     const duration = new Date() - startTime;
-    events.emitCacheEvent('read_time', opts, duration);
+    events.emitCacheEvent('read_time', opts, ctx, duration);
     return value;
   } catch (err) {
+    const duration = new Date() - startTime;
     if (err instanceof TimeoutError) {
-      events.emitCacheEvent('timeout', opts, ctx, err);
+      events.emitCacheEvent('timeout', opts, ctx, duration, err);
     } else {
-      events.emitCacheEvent('error', opts, ctx, err);
+      events.emitCacheEvent('error', opts, ctx, duration, err);
     }
     throw err;
   }
@@ -73,12 +74,13 @@ async function storeInCache(cache, segment, ctx, body, ttl, opts) {
   try {
     await pending;
     const duration = new Date() - startTime;
-    events.emitCacheEvent('write_time', opts, duration);
+    events.emitCacheEvent('write_time', opts, ctx, duration);
   } catch (err) {
+    const duration = new Date() - startTime;
     if (err instanceof TimeoutError) {
-      events.emitCacheEvent('timeout', opts, ctx, err);
+      events.emitCacheEvent('timeout', opts, ctx, duration, err);
     } else {
-      events.emitCacheEvent('error', opts, ctx, err);
+      events.emitCacheEvent('error', opts, ctx, duration, err);
     }
   }
 }

--- a/lib/events.js
+++ b/lib/events.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const EventEmitter = require('events');
 const events = new EventEmitter();
 
-function emitCacheEvent(event, opts, ctx, err) {
+function emitCacheEvent(event, opts, ctx, duration, err) {
   const name = opts && opts.name ? opts.name : null;
   const type = name ? `cache.${name}.${event}` : `cache.${event}`;
 
@@ -16,6 +16,7 @@ function emitCacheEvent(event, opts, ctx, err) {
     ctx.cacheStatus.push(event);
   }
 
+  ctx.cacheDuration = duration;
   events.emit(type, ctx, err);
 }
 

--- a/lib/maxAge.js
+++ b/lib/maxAge.js
@@ -33,7 +33,7 @@ module.exports = (cache, opts) => {
         const timeout = _.get(opts, 'connectionTimeout');
         await startCacheConnection({ cache, timeout, circuitBreaker });
       } catch (err) {
-        events.emitCacheEvent('connection_error', opts, ctx, err);
+        events.emitCacheEvent('connection_error', opts, ctx, null, err);
         if (_.get(opts, 'ignoreCacheErrors', false)) return next();
         throw err;
       }

--- a/lib/staleIfError.js
+++ b/lib/staleIfError.js
@@ -28,7 +28,7 @@ module.exports = (cache, opts) => {
         const timeout = _.get(opts, 'connectionTimeout');
         await startCacheConnection({ cache, timeout, circuitBreaker });
       } catch (err) {
-        events.emitCacheEvent('connection_error', opts, ctx, err);
+        events.emitCacheEvent('connection_error', opts, ctx, null, err);
         if (_.get(opts, 'ignoreCacheErrors', false)) return next();
         throw err;
       }

--- a/test/cache.js
+++ b/test/cache.js
@@ -120,8 +120,8 @@ describe('events', () => {
     const opts = {
       name: 'whatever'
     };
-    events.on(`cache.${opts.name}.write_time`, (duration) => {
-      writeDuration = duration;
+    events.on(`cache.${opts.name}.write_time`, (ctx) => {
+      writeDuration = ctx.cacheDuration;
     });
 
     const cache = createCache();
@@ -136,8 +136,8 @@ describe('events', () => {
     const opts = {
       name: 'whatever'
     };
-    events.on(`cache.${opts.name}.read_time`, (duration) => {
-      readDuration = duration;
+    events.on(`cache.${opts.name}.read_time`, (ctx) => {
+      readDuration = ctx.cacheDuration;
     });
     const cache = createCache();
     await cache.start();


### PR DESCRIPTION
## Description
- Fixed an issue with `read_time` and `write_time` events not passing the context through the `emitCacheEvent` function.

## Motivation and Context
- We're now setting keys onto the context in the `emitCacheEvent` function so we need that to be an object.

## Types of changes
- To keep the duration coming through, we're now setting it in the context in the `emitCacheEvent` function, similar to how we handle the `cacheStatus`.

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
